### PR TITLE
Updating goreleaser config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   main: main.go
 brews:
   - description: "my-cli-tool is an example."
-    github:
+    tap:
       owner: trussworks
       name: homebrew-tap
     homepage: "https://github.com/trussworks/my-cli-tool"
@@ -23,7 +23,7 @@ brews:
       email: infra+github@truss.works
 dockers:
   -
-    binaries:
+    ids:
       - my-cli-tool
     image_templates:
       - "trussworks/my-cli-tool:{{ .Tag }}"


### PR DESCRIPTION
When I was working on security-hub-collector, I was getting errors dealing with the goreleaser config; it didn't recognize "github" as a valid element and it said the docker "binaries" element was deprecated (https://goreleaser.com/deprecations#dockerbinaries). Based on what it looked like we were doing before, and what I could find in the docs, I've gone through and updated this to match what I *think* it should be now.